### PR TITLE
Readme: mention explicitly the required annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ from any dependencies that pull it in, otherwise you'll need to explicitly add i
 Start writing POJOs as abstract classes:
 
 ```java
+import org.immutables.value.Value.Immutable;
+
 @Immutable
 @HubSpotStyle
 public abstract class AbstractWidget {


### PR DESCRIPTION
A simple update to the readme that would have saved me an hour of rebuilds this afternoon. Explicitly name the import that provides that `@Immutable` annotation in the examples. IDEA had auto-imported `javax.annotation.concurrent.Immutable` instead.